### PR TITLE
make resonitepath in csproj slightly more cross-platform

### DIFF
--- a/ProtoFluxContextualActions/ProtoFluxContextualActions.csproj
+++ b/ProtoFluxContextualActions/ProtoFluxContextualActions.csproj
@@ -26,13 +26,15 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <TargetFramework>net9</TargetFramework>
         <ResoniteProjectType>mod</ResoniteProjectType>
         <ResoniteTarget>client</ResoniteTarget>
         <ResoniteInstallOnBuild>true</ResoniteInstallOnBuild>
-        <ResonitePath>D:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+        <ResonitePath Condition="'$(OS)' == 'Windows_NT' and Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+        <ResonitePath Condition="'$(OS)' != 'Windows_NT' and Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
+        <ResonitePath Condition="'$(ResonitePath)' == ''">D:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -79,7 +81,7 @@
         <Private>False</Private>
       </Reference>
     </ItemGroup>
-    
+
     <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(ResoniteInstallOnBuild)'=='true'">
         <Message Text="Attempting to copy $(TargetFileName) to $(ResonitePath)rml_mods" Importance="high" />
         <Copy SourceFiles="$(TargetDir)$(TargetFileName)" DestinationFolder="$(ResonitePath)rml_mods" ContinueOnError="true" />


### PR DESCRIPTION
should still be able to build on your machine if you don't have the two previous paths