### PR TITLE
Small Additions + Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 /.vscode
 ProtoFluxContextualActions.sln
+ProtoFluxContextualActions.slnx

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch.cs
@@ -76,7 +76,7 @@ internal static partial class ContextualSelectionActionsPatch
   [HarmonyPatch(typeof(ProtoFluxTool), nameof(ProtoFluxTool.OnPrimaryRelease))]
   internal static void PrimaryReleasePatch(ProtoFluxTool __instance, SyncRef<ProtoFluxElementProxy> ____currentProxy)
   {
-    if (!ProtoFluxContextualActions.ShouldDoDefaultActionOnPrimaryRelease()) return;
+    if (!ProtoFluxContextualActions.ShouldDoDefaultActionOnPrimaryRelease) return;
     if (!__instance.LocalUser.IsContextMenuOpen()) return;
     // only allow the contextmenu to trigger if the menu came from the tool
     if (__instance.LocalUser.GetUserContextMenu().CurrentSummoner != __instance) return;

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch.cs
@@ -260,8 +260,15 @@ internal static partial class ContextualSelectionActionsPatch
         if (!doConnect) return;
       }
 
-      var input = addedNode.NodeInputs
-          .FirstOrDefault(i => i.TargetType.IsGenericType && (outputProxy.OutputType.Value.IsAssignableFrom(i.TargetType.GenericTypeArguments[0]) || ProtoFlux.Core.TypeHelper.CanImplicitlyConvertTo(outputProxy.OutputType, i.TargetType.GenericTypeArguments[0])))
+      var outputType = outputProxy.OutputType.Value;
+
+      // collection types (in some cases) can be casted to the value input rather than the collection input.
+      var isCollectionType = TypeUtils.MatchInterface(outputType, typeof(ICollection<>), out var collectionType);
+      var input = !isCollectionType ? null : addedNode.NodeInputs
+        .FirstOrDefault(i => TypeUtils.MatchInterface(i.TargetType.GenericTypeArguments[0], collectionType!, out _));
+
+      input ??= addedNode.NodeInputs
+          .FirstOrDefault(i => i.TargetType.IsGenericType && (outputType.IsAssignableFrom(i.TargetType.GenericTypeArguments[0]) || ProtoFlux.Core.TypeHelper.CanImplicitlyConvertTo(outputProxy.OutputType, i.TargetType.GenericTypeArguments[0])))
           ?? (ISyncRef)addedNode.NodeInputLists.First().GetElement(0) ?? throw new Exception($"Could not find matching input of type '{outputProxy.OutputType}' in '{addedNode}'");
 
       addedNode.TryConnectInput(input, outputProxy.NodeOutput.Target, allowExplicitCast: false, undoable: true);

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch.cs
@@ -251,7 +251,7 @@ internal static partial class ContextualSelectionActionsPatch
     {
       // this is dumb
       // TODO: investigate why it's needed for casting to work
-      await new Updates();
+      await new Updates(2);
 
       if (item.onNodeSpawn != null)
       {

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -451,7 +451,7 @@ static partial class ContextualSelectionActionsPatch
       yield return new MenuItem(typeof(AssignRole));
     }
 
-    if (typeof(IWorldElement).IsAssignableFrom(outputType) && outputType != typeof(IWorldElement) && !outputType.IsUnmanaged() && outputType.IsAssignableFrom(typeof(object)))
+    if (typeof(IWorldElement).IsAssignableFrom(outputType) && outputType != typeof(IWorldElement))
     {
       yield return new MenuItem(
         typeof(ObjectCast<,>).MakeGenericType(outputType, typeof(IWorldElement)),

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -940,15 +940,9 @@ static partial class ContextualSelectionActionsPatch
           name: name,
           onNodeSpawn: (ProtoFluxNode newNode, ProtoFluxElementProxy proxy, ProtoFluxTool _) =>
           {
-            newNode.StartTask(async () =>
-            {
-              // we have to delay here to assign the variable in some cases, like if the wire was released.
-              await new Updates(1);
+            ISyncRef targetRef = newNode.GetReference(0);
 
-              ISyncRef targetRef = newNode.GetReference(0);
-
-              newNode.TryConnectReference(targetRef, outputProxy.Node.Target, false);
-            });
+            newNode.TryConnectReference(targetRef, outputProxy.Node.Target, false);
 
             return connectNode;
           },

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -940,11 +940,15 @@ static partial class ContextualSelectionActionsPatch
           name: name,
           onNodeSpawn: (ProtoFluxNode newNode, ProtoFluxElementProxy proxy, ProtoFluxTool _) =>
           {
-            ProtoFluxOutputProxy output = (ProtoFluxOutputProxy)proxy;
+            newNode.StartTask(async () =>
+            {
+              // we have to delay here to assign the variable in some cases, like if the wire was released.
+              await new Updates(1);
 
-            ISyncRef targetRef = newNode.GetReference(0);
+              ISyncRef targetRef = newNode.GetReference(0);
 
-            newNode.TryConnectReference(targetRef, outputProxy.Node.Target, undoable: true);
+              newNode.TryConnectReference(targetRef, outputProxy.Node.Target, false);
+            });
 
             return connectNode;
           },

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -140,7 +140,7 @@ static partial class ContextualSelectionActionsPatch
 
       yield return new MenuItem(typeof(DynamicImpulseTrigger), group: "Events");
 
-      bool shouldRelay = ProtoFluxContextualActions.ShouldUseRelays();
+      bool shouldRelay = ProtoFluxContextualActions.ShouldUseRelays;
       Type baseType = shouldRelay ? typeof(ObjectRelay<Slot>) : typeof(ChildrenCount);
 
       yield return new MenuItem(typeof(AllocatingUser), name: "Allocating User", group: "Slots");
@@ -481,7 +481,7 @@ static partial class ContextualSelectionActionsPatch
     }
 
 
-    if (outputType == typeof(IWorldElement) && ProtoFluxContextualActions.ShouldDisplayUnsupportedActions())
+    if (outputType == typeof(IWorldElement) && ProtoFluxContextualActions.ShouldDisplayUnsupportedActions)
     {
       yield return new MenuItem(typeof(IsRemoved));
       yield return new MenuItem(typeof(ReferenceID));
@@ -604,7 +604,7 @@ static partial class ContextualSelectionActionsPatch
             }
             setPositions();
 
-            await new Updates(ProtoFluxContextualActions.StructureReleaseUpdates());
+            await new Updates(ProtoFluxContextualActions.StructureReleaseUpdates);
 
             int i = 0;
             while (tempGrab.IsGrabbed && i < 200)

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -299,6 +299,10 @@ static partial class ContextualSelectionActionsPatch
       yield return new MenuItem(typeof(GET_String));
       yield return new MenuItem(typeof(FocusWorld));
     }
+    else if (typeof(IEnumerable<string>).IsAssignableFrom(outputType))
+    {
+      yield return new MenuItem(typeof(JoinString));
+    }
 
     else if (outputType == typeof(DateTime))
     {

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -507,34 +507,34 @@ static partial class ContextualSelectionActionsPatch
       yield return new MenuItem(typeof(AssignRole));
     }
 
-    // if (typeof(IWorldElement).IsAssignableFrom(outputType) && outputType != typeof(IWorldElement) && !outputType.IsUnmanaged() && outputType.IsAssignableFrom(typeof(object)))
-    // {
-    //   yield return new MenuItem(
-    //     typeof(ObjectCast<,>).MakeGenericType(outputType, typeof(IWorldElement)),
-    //     name: "IWorldElement", group: "Casts"
-    //   );
-    // }
-    // if (outputType != typeof(object))
-    // {
-    //   if (outputType.IsUnmanaged())
-    //   {
-    //     yield return new MenuItem(
-    //       typeof(ValueToObjectCast<>).MakeGenericType(outputType),
-    //       name: "Object", group: "Casts"
-    //     );
-    //   }
-    //   else if (ReflectionHelper.IsNullable(outputType))
-    //   {
-    //     yield return new MenuItem(typeof(NullableToObjectCast<>).MakeGenericType(Nullable.GetUnderlyingType(outputType) ?? outputType), name: "Object", group: "Casts");
-    //   }
-    //   else
-    //   {
-    //     yield return new MenuItem(
-    //       typeof(ObjectCast<,>).MakeGenericType(outputType, typeof(object)),
-    //       name: "Object", group: "Casts"
-    //     );
-    //   }
-    // }
+    if (typeof(IWorldElement).IsAssignableFrom(outputType) && outputType != typeof(IWorldElement) && !outputType.IsUnmanaged() && outputType.IsAssignableFrom(typeof(object)))
+    {
+      yield return new MenuItem(
+        typeof(ObjectCast<,>).MakeGenericType(outputType, typeof(IWorldElement)),
+        name: "IWorldElement", group: "Casts"
+      );
+    }
+    if (outputType != typeof(object))
+    {
+      if (outputType.IsUnmanaged() || typeof(ISphericalHarmonics).IsAssignableFrom(outputType))
+      {
+        yield return new MenuItem(
+          typeof(ValueToObjectCast<>).MakeGenericType(outputType),
+          name: "Object", group: "Casts"
+        );
+      }
+      else if (ReflectionHelper.IsNullable(outputType))
+      {
+        yield return new MenuItem(typeof(NullableToObjectCast<>).MakeGenericType(Nullable.GetUnderlyingType(outputType) ?? outputType), name: "Object", group: "Casts");
+      }
+      else if (outputType.IsClass)
+      {
+        yield return new MenuItem(
+          typeof(ObjectCast<,>).MakeGenericType(outputType, typeof(object)),
+          name: "Object", group: "Casts"
+        );
+      }
+    }
 
 
     if (outputType == typeof(IWorldElement) && ProtoFluxContextualActions.ShouldDisplayUnsupportedActions())

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -60,7 +60,7 @@ using ProtoFlux.Runtimes.Execution.Nodes.FrooxEngine.Elements;
 using ProtoFlux.Runtimes.Execution.Nodes.FrooxEngine.Network;
 using ProtoFlux.Runtimes.Execution.Nodes.FrooxEngine.Animation;
 using ProtoFlux.Runtimes.Execution.Nodes.FrooxEngine.Security;
-using ProtoFlux.Runtimes.Execution.Nodes.Collections;
+using System.Reflection;
 
 namespace ProtoFluxContextualActions.Patches;
 
@@ -500,43 +500,19 @@ static partial class ContextualSelectionActionsPatch
             Type lengthInputNode = ProtoFluxHelper.GetInputNode(typeof(int));
             Type numberStyleNode = ProtoFluxHelper.GetInputNode(typeof(NumberStyles));
 
-            ProtoFluxNode? thisRefIDObjectCastNode = null;
-            ProtoFluxNode? thisToStringNode = null;
-            ProtoFluxNode? thisStringRemoveNode = null;
-            ProtoFluxNode? thisParseULongNode = null;
-            ProtoFluxNode? thisLengthInputNode = null;
-            ProtoFluxNode? thisNumberStyleNode = null;
+            ProtoFluxNode? SpawnNode(Type nodeType)
+            {
+              return tool.SpawnNode(nodeType, node => node.EnsureVisual());
+            }
 
-            tool.SpawnNode(refIDObjectCastNode, newNode =>
-            {
-              thisRefIDObjectCastNode = newNode;
-              newNode.EnsureVisual();
-            });
-            tool.SpawnNode(toStringNode, newNode =>
-            {
-              thisToStringNode = newNode;
-              newNode.EnsureVisual();
-            });
-            tool.SpawnNode(stringRemoveNode, newNode =>
-            {
-              thisStringRemoveNode = newNode;
-              newNode.EnsureVisual();
-            });
-            tool.SpawnNode(parseULongNode, newNode =>
-            {
-              thisParseULongNode = newNode;
-              newNode.EnsureVisual();
-            });
-            tool.SpawnNode(lengthInputNode, newNode =>
-            {
-              thisLengthInputNode = newNode;
-              newNode.EnsureVisual();
-            });
-            tool.SpawnNode(numberStyleNode, newNode =>
-            {
-              thisNumberStyleNode = newNode;
-              newNode.EnsureVisual();
-            });
+            ProtoFluxNode? refObjCast = SpawnNode(refIDObjectCastNode);
+            ProtoFluxNode? toStr = SpawnNode(toStringNode);
+            ProtoFluxNode? strRemove = SpawnNode(stringRemoveNode);
+            ProtoFluxNode? parseULong = SpawnNode(parseULongNode);
+            ProtoFluxNode? lenInput = SpawnNode(lengthInputNode);
+            ProtoFluxNode? styleInput = SpawnNode(numberStyleNode);
+
+            ProtoFluxNode?[] nodes = [node, refObjCast, toStr, strRemove, parseULong, lenInput, styleInput];
 
             await new Updates(6);
 
@@ -546,87 +522,53 @@ static partial class ContextualSelectionActionsPatch
             tempSlot.CopyTransform(nodeSlot);
             nodeSlot.Parent = tempSlot;
 
-            if (
-              thisRefIDObjectCastNode == null ||
-              thisToStringNode == null ||
-              thisStringRemoveNode == null ||
-              thisParseULongNode == null ||
-              thisLengthInputNode == null ||
-              thisNumberStyleNode == null)
+            if (nodes.Any(n => n == null))
             {
-              node.Slot.Destroy();
-              thisRefIDObjectCastNode?.Slot.Destroy();
-              thisToStringNode?.Slot.Destroy();
-              thisStringRemoveNode?.Slot.Destroy();
-              thisParseULongNode?.Slot.Destroy();
-              thisLengthInputNode?.Slot.Destroy();
-              thisNumberStyleNode?.Slot.Destroy();
+              foreach (var node in nodes)
+              {
+                node?.Slot.Destroy();
+              }
               return;
             }
 
             node.World.BeginUndoBatch("Create RefID -> ULong");
 
-            node.Slot.CreateSpawnUndoPoint("Spawn Object Cast");
-            thisRefIDObjectCastNode.Slot.CreateSpawnUndoPoint("Spawn ToString Node");
-            thisToStringNode.Slot.CreateSpawnUndoPoint("Spawn ToString Node");
-            thisStringRemoveNode.Slot.CreateSpawnUndoPoint("Spawn String Remove Node");
-            thisParseULongNode.Slot.CreateSpawnUndoPoint("Spawn Parse ULong");
-            thisLengthInputNode.Slot.CreateSpawnUndoPoint("Spawn Length Input");
-            thisNumberStyleNode.Slot.CreateSpawnUndoPoint("Spawn Number Styles Input");
+            foreach (var node in nodes)
+            {
+              node!.Slot.CreateSpawnUndoPoint("Spawn Node");
+            }
 
             // Inputs and outputs
             INodeOutput inputRelay = node.GetOutput(0);
 
-            ISyncRef refIDInstance = thisRefIDObjectCastNode.GetInput(0);
-            INodeOutput refIDValue = thisRefIDObjectCastNode.GetOutput(0);
-            ISyncRef objectInstance = thisToStringNode.GetInput(0);
-            INodeOutput objectValue = thisToStringNode.GetOutput(0);
-            ISyncRef stringRemoveInstance = thisStringRemoveNode.GetInput(0);
-            ISyncRef stringRemoveLength = thisStringRemoveNode.GetInput(2);
-            INodeOutput stringRemoveValue = thisStringRemoveNode.GetOutput(0);
-            ISyncRef parseULongInstance = thisParseULongNode.GetInput(0);
-            ISyncRef parseULongStyle = thisParseULongNode.GetInput(1);
+            ISyncRef refIDInstance = refObjCast!.GetInput(0);
+            INodeOutput refIDValue = refObjCast.GetOutput(0);
+            ISyncRef objectInstance = toStr!.GetInput(0);
+            INodeOutput objectValue = toStr.GetOutput(0);
+            ISyncRef stringRemoveInstance = strRemove!.GetInput(0);
+            ISyncRef stringRemoveLength = strRemove.GetInput(2);
+            INodeOutput stringRemoveValue = strRemove.GetOutput(0);
+            ISyncRef parseULongInstance = parseULong!.GetInput(0);
+            ISyncRef parseULongStyle = parseULong.GetInput(1);
 
-            INodeOutput lengthValue = thisLengthInputNode.GetOutput(0);
-            INodeOutput numberStylesValue = thisNumberStyleNode.GetOutput(0);
+            INodeOutput lengthValue = lenInput!.GetOutput(0);
+            INodeOutput numberStylesValue = styleInput!.GetOutput(0);
 
             refIDInstance.Target = inputRelay;
             objectInstance.Target = refIDValue;
 
-            stringRemoveInstance.Target = thisToStringNode;
+            stringRemoveInstance.Target = toStr;
             parseULongInstance.Target = stringRemoveValue;
 
             stringRemoveLength.Target = lengthValue;
             parseULongStyle.Target = numberStylesValue;
 
-            (thisLengthInputNode as FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.ValueInput<int>)?.Value.Value = 2;
-            (thisNumberStyleNode as FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.ValueInput<NumberStyles>)?.Value.Value = NumberStyles.HexNumber;
-
-            // Positions
-            float3 baseUp = nodeSlot.Up;
-            float3 baseRight = nodeSlot.Right;
-
-            void LocalTransformNode(ProtoFluxNode input, float X, float Y)
-            {
-              Slot target = input.Slot;
-              target.CopyTransform(nodeSlot);
-              target.Parent = nodeSlot.Parent;
-              target.GlobalPosition += (baseUp * Y) + (baseRight * X);
-            }
-
-            LocalTransformNode(thisRefIDObjectCastNode, 0.09f, -0.00375f);
-
-            LocalTransformNode(thisToStringNode, 0.18f, -0.03f);
-            LocalTransformNode(thisStringRemoveNode, 0.33f, -0.03f);
-            LocalTransformNode(thisParseULongNode, 0.495f, -0.03f);
-
-            LocalTransformNode(thisLengthInputNode, 0.18f, -0.135f);
-            LocalTransformNode(thisNumberStyleNode, 0.27f, 0.075f);
+            (lenInput as FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.ValueInput<int>)?.Value.Value = 2;
+            (styleInput as FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.ValueInput<NumberStyles>)?.Value.Value = NumberStyles.HexNumber;
 
             node.World.EndUndoBatch();
 
-            ProtoFluxNode?[] allNodes = [node, thisRefIDObjectCastNode, thisToStringNode, thisStringRemoveNode, thisParseULongNode, thisLengthInputNode, thisNumberStyleNode];
-            foreach (var node in allNodes)
+            foreach (var node in nodes)
             {
               if (node == null) continue;
               if (node.IsRemoved) continue;
@@ -634,21 +576,58 @@ static partial class ContextualSelectionActionsPatch
             }
             var tempGrab = tempSlot.AttachComponent<Grabbable>();
 
-            await new Updates(240);
+            // for fixing prints that snap the nodes early
+            await new Updates(6);
+
+            // Positions
+            void setPositions()
+            {
+              float3 baseUp = nodeSlot.Up;
+              float3 baseRight = nodeSlot.Right;
+
+              void LocalTransformNode(ProtoFluxNode input, float X, float Y)
+              {
+                Slot target = input.Slot;
+                target.CopyTransform(nodeSlot);
+                target.Parent = nodeSlot.Parent;
+                target.GlobalPosition += (baseUp * Y) + (baseRight * X);
+              }
+
+              LocalTransformNode(refObjCast, 0.09f, -0.00375f);
+
+              LocalTransformNode(toStr, 0.18f, -0.03f);
+              LocalTransformNode(strRemove, 0.33f, -0.03f);
+              LocalTransformNode(parseULong, 0.495f, -0.03f);
+
+              LocalTransformNode(lenInput, 0.18f, -0.135f);
+              LocalTransformNode(styleInput, 0.27f, 0.075f);
+            }
+            setPositions();
+
+            await new Updates(ProtoFluxContextualActions.StructureReleaseUpdates());
+
             int i = 0;
             while (tempGrab.IsGrabbed && i < 200)
             {
               await new Updates(5);
               i++;
             }
-            foreach (var node in allNodes)
+            foreach (var node in nodes)
             {
               if (node == null) continue;
               if (node.IsRemoved) continue;
-              node.Slot.GetComponent<Grabbable>().Enabled = true;
+              var nodeGrabbable = node.Slot.GetComponent<Grabbable>();
+              nodeGrabbable.Enabled = true;
+              // send a drop event, just in case
+              typeof(Grabbable).GetMethod("RunGrabEvent", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(nodeGrabbable, [true]);
             }
 
             tempSlot.Destroy(origParent);
+
+            // set positions again after everything / make lightprint not break            
+            await new Updates(3);
+
+            setPositions();
           });
 
           return true;

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems.cs
@@ -143,63 +143,7 @@ static partial class ContextualSelectionActionsPatch
       bool shouldRelay = ProtoFluxContextualActions.ShouldUseRelays();
       Type baseType = shouldRelay ? typeof(ObjectRelay<Slot>) : typeof(ChildrenCount);
 
-      yield return new MenuItem(
-        typeof(ObjectCast<Slot, IWorldElement>),
-        name: "Allocating User",
-        group: "Slots",
-        onNodeSpawn: (ProtoFluxNode node, ProtoFluxElementProxy proxy, ProtoFluxTool tool) =>
-        {
-          tool.StartTask(async () =>
-          {
-            // Node spawning
-            Type allocNode = typeof(FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.FrooxEngine.References.AllocatingUser);
-            ProtoFluxNode? thisAllocNode = null;
-
-            tool.SpawnNode(allocNode, newNode =>
-            {
-              thisAllocNode = newNode;
-              newNode.EnsureVisual();
-            });
-
-            await new Updates(3);
-
-            if (thisAllocNode == null)
-            {
-              node.Slot.Destroy();
-              return;
-            }
-
-            node.World.BeginUndoBatch("Create Allocating User");
-
-            node.Slot.CreateSpawnUndoPoint("Spawn Object Cast");
-            thisAllocNode.Slot.CreateSpawnUndoPoint("Spawn Allocating User");
-
-            // Inputs and outputs
-            INodeOutput inputRelay = node.GetOutput(0);
-
-            ISyncRef allocInstance = thisAllocNode.GetInput(0);
-
-            allocInstance.Target = inputRelay;
-
-            // Positions
-            float3 baseUp = node.Slot.Up;
-            float3 baseRight = node.Slot.Right;
-
-            void LocalTransformNode(ProtoFluxNode input, float X, float Y)
-            {
-              Slot target = input.Slot;
-              target.CopyTransform(node.Slot);
-              target.GlobalPosition += (baseUp * Y) + (baseRight * X);
-            }
-
-            LocalTransformNode(thisAllocNode, 0.09f, 0.00375f);
-
-            node.World.EndUndoBatch();
-          });
-
-          return true;
-        }
-      );
+      yield return new MenuItem(typeof(AllocatingUser), name: "Allocating User", group: "Slots");
 
     }
 

--- a/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems/CollectionItems.cs
+++ b/ProtoFluxContextualActions/Patches/ContextualSelectionActionsPatch/OutputItems/CollectionItems.cs
@@ -164,6 +164,11 @@ static partial class ContextualSelectionActionsPatch
       var keyType = dictionaryType.GenericTypeArguments[0];
       var valueType = dictionaryType.GenericTypeArguments[1];
 
+      // nodes like Clear<,> require KVPair, so just construct the type for when its needed.
+      var kvType = typeof(KeyValuePair<,>).MakeGenericType(keyType, valueType);
+
+      yield return new(typeof(Clear<,>).MakeGenericType(outputType, kvType), group: "Dictionaries");
+
       // I wish I didn't need to manually check these but generic creation is *not* failing and throwing with unmanaged types despite the constraint so...
       var addItemWithKey = (valueType.IsUnmanaged(), keyType.IsUnmanaged()) switch
       {

--- a/ProtoFluxContextualActions/ProtoFluxContextualActions.cs
+++ b/ProtoFluxContextualActions/ProtoFluxContextualActions.cs
@@ -152,20 +152,20 @@ public class ProtoFluxContextualActions : ResoniteMod
     }
   }
 
-  internal static bool ShouldUseRelays() => fluxStructureRelays.Value;
-  internal static int StructureReleaseUpdates() => fluxStructureReleaseUpdates.Value;
+  internal static bool ShouldUseRelays => fluxStructureRelays.Value;
+  internal static int StructureReleaseUpdates => fluxStructureReleaseUpdates.Value;
 
-  internal static bool ShouldTryFixFlick() => tryFixFlick.Value;
+  internal static bool ShouldTryFixFlick => tryFixFlick.Value;
 
-  internal static bool ShouldTryKeepContextPosition() => tryKeepContextPosition.Value;
+  internal static bool ShouldTryKeepContextPosition => tryKeepContextPosition.Value;
 
-  internal static int GetMaxItemsPerPage() => maxItemsPerPage.Value;
+  internal static int MaxItemsPerPage => maxItemsPerPage.Value;
 
-  internal static bool ShouldDoDefaultActionOnPrimaryRelease() => defaultActionOnPrimaryRelease.Value;
+  internal static bool ShouldDoDefaultActionOnPrimaryRelease => defaultActionOnPrimaryRelease.Value;
 
-  internal static bool ShouldDisplayBackButton() => showBackButton.Value;
+  internal static bool ShouldDisplayBackButton => showBackButton.Value;
 
-  internal static bool ShouldDisplayUnsupportedActions() => showUnsupportedActions.Value;
+  internal static bool ShouldDisplayUnsupportedActions => showUnsupportedActions.Value;
 
-  internal static MenuVisual GetMenuVisual() => currentMenuVisual.Value;
+  internal static MenuVisual MenuVisual => currentMenuVisual.Value;
 }

--- a/ProtoFluxContextualActions/ProtoFluxContextualActions.cs
+++ b/ProtoFluxContextualActions/ProtoFluxContextualActions.cs
@@ -35,6 +35,8 @@ public class ProtoFluxContextualActions : ResoniteMod
   [AutoRegisterConfigKey]
   private static readonly ModConfigurationKey<bool> fluxStructureRelays = new("Structure Relays", "If \"Flux Structures\" should contain relays", () => true);
   [AutoRegisterConfigKey]
+  private static readonly ModConfigurationKey<int> fluxStructureReleaseUpdates = new("Structure Release Updates", "How many updates to allow for structures to be 'released' from the 'global grabber'", () => 240);
+  [AutoRegisterConfigKey]
   private static readonly ModConfigurationKey<bool> tryFixFlick = new("Try Fix Context Flick", "If the context menu should attempt to fix flicking", () => true);
   [AutoRegisterConfigKey]
   private static readonly ModConfigurationKey<bool> tryKeepContextPosition = new("Try Keep Context Menu Position", "If the context menu should attempt to stay in the same position", () => false);
@@ -151,6 +153,7 @@ public class ProtoFluxContextualActions : ResoniteMod
   }
 
   internal static bool ShouldUseRelays() => fluxStructureRelays.Value;
+  internal static int StructureReleaseUpdates() => fluxStructureReleaseUpdates.Value;
 
   internal static bool ShouldTryFixFlick() => tryFixFlick.Value;
 

--- a/ProtoFluxContextualActions/Utils/ContextUtils.cs
+++ b/ProtoFluxContextualActions/Utils/ContextUtils.cs
@@ -13,14 +13,14 @@ internal class ContextMenuCreator
 {
   internal async Task<ContextMenu> CreateContextMenu(ProtoFluxTool tool, bool isInitialMenu = false)
   {
-    bool shouldKeepPositionConfig = ProtoFluxContextualActions.ShouldTryKeepContextPosition();
+    bool shouldKeepPositionConfig = ProtoFluxContextualActions.ShouldTryKeepContextPosition;
     bool shouldKeepPosition = !isInitialMenu && shouldKeepPositionConfig;
     var menu = await tool.LocalUser.OpenContextMenu(tool, tool.Slot, options: new ContextMenuOptions { speedOverride = 12, keepPosition = shouldKeepPosition });
 
     // stupid attempt to force the contextmenu to use flick, as it tends to fail in vr at lower framerates?
     _ = tool.StartTask(async () =>
     {
-      bool shouldTryFixFlick = ProtoFluxContextualActions.ShouldTryFixFlick();
+      bool shouldTryFixFlick = ProtoFluxContextualActions.ShouldTryFixFlick;
       if (!shouldTryFixFlick) return;
       await new Updates(3);
       var user = Engine.Current.WorldManager.FocusedWorld.LocalUser;

--- a/ProtoFluxContextualActions/Utils/GroupManager.cs
+++ b/ProtoFluxContextualActions/Utils/GroupManager.cs
@@ -37,7 +37,7 @@ internal enum MenuVisual
 internal class GroupManager
 {
   // Page Config
-  int MaxPerPage => ProtoFluxContextualActions.GetMaxItemsPerPage(); // Maximum possible items in the context menu, excluding Previous/Next/Back buttons
+  int MaxPerPage => ProtoFluxContextualActions.MaxItemsPerPage; // Maximum possible items in the context menu, excluding Previous/Next/Back buttons
   const bool ShowBackOnAllPages = false;
 
   // Folder Config
@@ -74,7 +74,7 @@ internal class GroupManager
     });
 
     // Would be read from mod config instead of a constant
-    MenuVisual selectedVisual = overrideVisual ?? ProtoFluxContextualActions.GetMenuVisual();
+    MenuVisual selectedVisual = overrideVisual ?? ProtoFluxContextualActions.MenuVisual;
 
     currentVisual = selectedVisual switch
     {
@@ -271,7 +271,7 @@ internal class GroupManager
     if (currentTool.IsRemoved) return;
     bool showPreviousButton = pageIndex > 0;
     bool showNextButton = pageIndex < Items.Count - 1;
-    bool showBackButton = ProtoFluxContextualActions.ShouldDisplayBackButton()
+    bool showBackButton = ProtoFluxContextualActions.ShouldDisplayBackButton
             && GroupedItems.Count != 1
             && (ShowBackOnAllPages || pageIndex == 0)
             && !isRoot;


### PR DESCRIPTION
Most of this is fixes to my own code, but 2 new nodes have been added too.
Its a smaller change, so this is what has been changed/added:

- IEnumerable<string> -> JoinString
- IDictionary<,> -> Clear
- Fix certain collection types from being inputted into the wrong input
- - Example: `SyncRefList<IWorldElement>` -> `Add` would put the SyncRefList into `Element` instead of `Collection`
- Bring back object/IWorldElement selection casts
- Fix implicit casts not working if the wire is not held
- Fix IVariable -> Write not assigning the variable if the wire is not held
- Slot -> AllocatingUser now uses implicit cast, making it a lot smaller and simpler
- IWorldElement -> 'RefID->ULong' has been compacted and improved slightly
- Config options are now like `MaxItemsPerPage` instead of `MaxItemsPerPage()`

I have not encountered any issues on my end so far, so it should be stable.
if not, i can likely fix it myself if i know the setup to replicate.